### PR TITLE
Bump python version to 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = ["version"]
 readme = "README.md"
 urls = { Organization = "https://2i2c.org" }
 
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dependencies = [
   "sphinx-book-theme>=0.1.7",
 ]


### PR DESCRIPTION
This ensures that we can use the STB because it currently only allows 3.8+!