### PR TITLE
Pin book theme to 0.3 series

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ urls = { Organization = "https://2i2c.org" }
 
 requires-python = ">=3.8"
 dependencies = [
-  "sphinx-book-theme@https://github.com/executablebooks/sphinx-book-theme/archive/refs/heads/master.zip",
+  "sphinx-book-theme>=0.3.0.rc1,<0.4",
 ]
 
 license = { file = "LICENSE"}


### PR DESCRIPTION
This pins the book theme to the 0.3 series (release candidates and above). So that we're not pulling directly from master anymore.

closes #9 