### PR TITLE
Fix a bug that made icon links show in sidebar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ urls = { Organization = "https://2i2c.org" }
 
 requires-python = ">=3.8"
 dependencies = [
-  "sphinx-book-theme>=1.0.0rc1",
+  "sphinx-book-theme>=1.0.0",
   "sphinxext-opengraph",
   "sphinx-copybutton",
   "sphinx-togglebutton",

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/theme.conf
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/theme.conf
@@ -1,6 +1,8 @@
 [theme]
 inherit = sphinx_book_theme
 stylesheet = styles/sphinx-2i2c-theme.css
+# Remove icon-links.html from sidebar since we put it in the navbar
+sidebars = navbar-logo.html, sbt-sidebar-nav.html
 
 [options]
 # Header / navbar.


### PR DESCRIPTION
This removes icon links from the sidebar, since we are instead using them in the header.