### PR TITLE
ENH: Redirect page.html to page/index.html if dirhtml builder

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,12 @@
 version: 2
 
 python:
-  version: "3.8"
+  version: "3.9"
   install:
     - method: pip
       path: .
     - requirements: docs/requirements.txt
  
+ # Build documentation in the docs/ directory with Sphinx
+sphinx:
+   builder: dirhtml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: "3.9"
+  version: "3.8"
   install:
     - method: pip
       path: .

--- a/docs/features.md
+++ b/docs/features.md
@@ -41,6 +41,16 @@ We download the Mozilla Fira CSS and embed it in our side, since this is what ou
 
 We also define several custom CSS rules to handle a header with cross-organization links.
 
+## Redirect to `dirhtml`
+
+2i2c's documentation uses the `dirhtml` builder so that pages exist at `pagename/index.html` instead of `pagename.html`.
+However, the Sphinx default uses the `html` builder, and our documentation is often already built this way.
+This theme includes a helper event callback that does two things:
+
+- If `dirhtml` is the builder, create files to redirect `pagename.html` to `pagename/index.html`.
+  This ensures that old `html` builder links redirect.
+- If `html` is the builder, raise a warning that the `dirhtml` builder should be used instead.
+
 ## Extensions
 
 **`sphinxext.opengraph`** adds OpenGraph tags to each of our sites.

--- a/docs/features.md
+++ b/docs/features.md
@@ -49,6 +49,7 @@ However, the Sphinx default uses the `html` builder, and our documentation often
 [^1]: In practice, this creates a file at `pagename/index.html`.
       When a user visits `mysite.org/pagename`, the browser tells you it is a directory.
       By default, browsers will then look for an `index.html` file in that directory and display it.
+      This function creates _another_ file at `pagename.html` and makes it redirect to `pagename/`, and thus displays `pagename/index.html`.
 
 To avoid broken links, this theme includes a helper event callback that does two things:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -43,11 +43,16 @@ We also define several custom CSS rules to handle a header with cross-organizati
 
 ## Redirect to `dirhtml`
 
-2i2c's documentation uses the `dirhtml` builder so that pages exist at `pagename/index.html` instead of `pagename.html`.
-However, the Sphinx default uses the `html` builder, and our documentation is often already built this way.
-This theme includes a helper event callback that does two things:
+2i2c's documentation uses the `dirhtml` builder so that links look like `mysite.org/pagename` instead of `mysite.org/pagename.html`.[^1]
+However, the Sphinx default uses the `html` builder, and our documentation often has historical links from earlier iterations where we used the `html` builder.
 
-- If `dirhtml` is the builder, create files to redirect `pagename.html` to `pagename/index.html`.
+[^1]: In practice, this creates a file at `pagename/index.html`.
+      When a user visits `mysite.org/pagename`, the browser tells you it is a directory.
+      By default, browsers will then look for an `index.html` file in that directory and display it.
+
+To avoid broken links, this theme includes a helper event callback that does two things:
+
+- If `dirhtml` is the builder, create files so that `pagename.html` redirects to `pagename`.
   This ensures that old `html` builder links redirect.
 - If `html` is the builder, raise a warning that the `dirhtml` builder should be used instead.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,10 +16,10 @@ nox.options.reuse_existing_virtualenvs = True
 @nox.session
 def docs(session):
     session.install("-r", "docs/requirements.txt")
-    build_command = ["-b", "html", "docs", "docs/_build/html"]
+    build_command = ["-b", "dirhtml", "docs", "docs/_build/dirhtml"]
     if "live" in session.posargs:
         session.install("-e", ".[dev]")
-        session.run("stb", "serve", "docs")
+        session.run("stb", "serve", "--builder", "dirhtml", "docs")
     else:
         session.install(".[dev]")
         session.run("stb", "compile")

--- a/src/sphinx_2i2c_theme/html2dirhtml.py
+++ b/src/sphinx_2i2c_theme/html2dirhtml.py
@@ -1,0 +1,39 @@
+from sphinx.util import logging
+from pathlib import Path
+
+LOGGER = logging.getLogger(__name__)
+
+REDIRECT_TEMPLATE = """
+<html>
+    <head>
+        <noscript>
+            <meta http-equiv="refresh" content="0; url={rel_url}"/>
+        </noscript>
+    </head>
+    <body>
+        <script>
+            window.location.href = '{rel_url}' + (window.location.search || '') + (window.location.hash || '');
+        </script>
+        <p>You should have been redirected.</p>
+        <a href="{rel_url}">If not, click here to continue.</a>
+    </body>
+</html>
+"""
+
+def redirect_from_html_to_dirhtml(app, pagename, templatename, context, doctree):
+    """If the dirhtml builder is used, redirect pagename.html to pagename/index.html"""
+    if not hasattr(app, "builder"):
+        return
+    if app.builder.name == "dirhtml":
+        # Assume that "pagename.html" needs to redirect to pagename/index.html"
+        path_html = (Path(app.outdir) / pagename).with_suffix(".html")
+        page_folder = pagename.split("/")[-1]
+
+        # Create the direct directory and write a new index.html file
+        path_html.parent.mkdir(exist_ok=True, parents=True)
+        path_html.write_text(REDIRECT_TEMPLATE.format(rel_url=page_folder))
+
+        LOGGER.info(f"Redirecting {pagename}.html to {pagename}/index.html")
+
+    elif app.builder.name == "html":
+        LOGGER.warn("Use the dirhtml builder instead of html builder!")

--- a/src/sphinx_2i2c_theme/html2dirhtml.py
+++ b/src/sphinx_2i2c_theme/html2dirhtml.py
@@ -21,7 +21,7 @@ REDIRECT_TEMPLATE = """
 """
 
 def redirect_from_html_to_dirhtml(app, pagename, templatename, context, doctree):
-    """If the dirhtml builder is used, redirect pagename.html to pagename/index.html"""
+    """If dirhtml builder is used, redirect pagename.html to the directory `pagename`"""
     if not hasattr(app, "builder"):
         return
     if app.builder.name == "dirhtml":
@@ -33,7 +33,7 @@ def redirect_from_html_to_dirhtml(app, pagename, templatename, context, doctree)
         path_html.parent.mkdir(exist_ok=True, parents=True)
         path_html.write_text(REDIRECT_TEMPLATE.format(rel_url=page_folder))
 
-        LOGGER.info(f"Redirecting {pagename}.html to {pagename}/index.html")
+        LOGGER.info(f"Redirecting {pagename}.html to {pagename}")
 
     elif app.builder.name == "html":
         LOGGER.warn("Use the dirhtml builder instead of html builder!")


### PR DESCRIPTION
This adds an event callback that:

- Checks if `dirhtml` is the builder
- If so, makes `pagename.html` redirect to `pagename/index.html`.

This ensures that old links that were used with the `html` builder will redirect properly.

It also cleans up helper functions that we were copy/pasting from pydata-sphinx-theme, and instead just directly importing them.

### Example

As an example, this link:

[`https://sphinx-2i2c-theme--18.org.readthedocs.build/en/18/features.html`](https://sphinx-2i2c-theme--18.org.readthedocs.build/en/18/features.html) should redirect to [`https://sphinx-2i2c-theme--18.org.readthedocs.build/en/18/features`](https://sphinx-2i2c-theme--18.org.readthedocs.build/en/18/features)
### References

- first step in https://github.com/2i2c-org/team-compass/issues/666