### PR TITLE
ENH: Add a rel=me link for mastodon

### DIFF
--- a/src/sphinx_2i2c_theme/__init__.py
+++ b/src/sphinx_2i2c_theme/__init__.py
@@ -43,6 +43,10 @@ def update_config(app):
             "name": "Mastodon",
             "url": "https://hachyderm.io/@2i2c_org",
             "icon": "fa-brands fa-mastodon",
+            # This allows us to verify this page in Mastodon
+            "attributes": {
+               "rel" : "me",
+            },
         },
         {
             "name": "Contact",


### PR DESCRIPTION
This adds a `rel=me` link for our Mastodon link, which will allow us to verify these websites on [the 2i2c mastodon profile](https://hachyderm.io/@2i2c_org). See [the mastodon docs](https://docs.joinmastodon.org/user/profile/) for details.