### PR TITLE
Update to latest book theme and simplify UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ urls = { Organization = "https://2i2c.org" }
 
 requires-python = ">=3.8"
 dependencies = [
-  "sphinx-book-theme>=1.0.1",
+  "sphinx-book-theme>=1.1.0",
   "sphinxext-opengraph",
   "sphinx-copybutton",
   "sphinx-togglebutton",

--- a/src/sphinx_2i2c_theme/__init__.py
+++ b/src/sphinx_2i2c_theme/__init__.py
@@ -65,7 +65,7 @@ def update_config(app):
 
 def hash_html_assets(app, pagename, templatename, context, doctree):
     assets = ["styles/sphinx-2i2c-theme.css"]
-    hash_assets_for_files(assets, THEME_PATH / "static", context)
+    hash_assets_for_files(assets, THEME_PATH / "static", context, app)
 
 
 def activate_extensions(app, extensions):

--- a/src/sphinx_2i2c_theme/assets/styles/sections/_footer.scss
+++ b/src/sphinx_2i2c_theme/assets/styles/sections/_footer.scss
@@ -1,0 +1,20 @@
+// The icon links to the right
+.bd-footer .footer-items__end {
+  justify-content: start;
+
+  .navbar-icon-links {
+    flex-direction: row-reverse;
+  }
+}
+
+// The 2i2c-wide footer links
+ul.footer-links {
+  padding-left: 0;
+  list-style: none;
+
+  button {
+    color: var(--pst-color-link);
+    padding-left: 0;
+  }
+}
+

--- a/src/sphinx_2i2c_theme/assets/styles/sphinx-2i2c-theme.scss
+++ b/src/sphinx_2i2c_theme/assets/styles/sphinx-2i2c-theme.scss
@@ -7,5 +7,6 @@
 @import "base/typography";
 @import "components/logo";
 @import "components/support-button";
+@import "sections/footer";
 @import "sections/header";
 @import "sections/sidebar-primary";

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-content-footer.html
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-content-footer.html
@@ -1,0 +1,2 @@
+{%- if version %}<p id="footer-version">Version <span>{{ version }}</span>.</p>{% endif %}
+<p id="footer-attribution">By the <a id="footer-link" href='https://2i2c.org'>International Interactive Computing Collaboration</a> (2i2c)</p>

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-footer.html
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-footer.html
@@ -1,2 +1,19 @@
-{%- if version %}<p id="footer-version">Version <span>{{ version }}</span>.</p>{% endif %}
-<p id="footer-attribution">By the <a id="footer-link" href='https://2i2c.org'>International Interactive Computing Collaboration</a> (2i2c)</p>
+{% set header_config = [
+  ("https://docs.2i2c.org/en/latest/", "Service Docs"),
+  ("https://infrastructure.2i2c.org/en/latest/", "Infrastructure Guide"),
+  ("https://team-compass.2i2c.org/", "2i2c Team Compass"),
+  ("https://2i2c.org/", "2i2c.org"),
+]
+%}
+<p class="footer-links-title">2i2c links</p>
+<ul class="footer-links">
+  {% for url, text in header_config %}
+  <li class="footer-link-item">
+    <a href="{{ url }}">
+      <button class="btn">
+        {{ text }}
+      </button>
+    </a>
+  </li>
+  {% endfor %}
+</ul>

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-header-links.html
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-header-links.html
@@ -1,8 +1,6 @@
 {% set header_config = [
   ("https://docs.2i2c.org/en/latest/", "Service Docs"),
   ("https://infrastructure.2i2c.org/en/latest/", "Infrastructure Guide"),
-  ("https://team-compass.2i2c.org/", "Team Compass"),
-  ("https://2i2c.org/", "2i2c.org"),
 ]
 %}
 <ul class="header-dropdown-links navbar-nav d-flex">

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/theme.conf
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/theme.conf
@@ -2,7 +2,7 @@
 inherit = sphinx_book_theme
 stylesheet = styles/sphinx-2i2c-theme.css
 # Remove icon-links.html from sidebar since we put it in the navbar
-sidebars = navbar-logo.html, sbt-sidebar-nav.html
+sidebars = navbar-logo.html, search-button-field.html, sbt-sidebar-nav.html
 
 [options]
 # Header / navbar.
@@ -14,3 +14,5 @@ navbar_persistent = components/2i2c-support-button.html
 
 # Footer
 footer_start = components/2i2c-footer.html
+footer_end = icon-links.html, components/2i2c-support-button.html
+footer_content_items = 2i2c-content-footer.html


### PR DESCRIPTION
This updates to the latest Sphinx Book Theme, and makes some minor adjustments to the menu options that are present in the header and the footer.

It removes the 2i2c.org and team compass links, and puts them in a footer where we can collect a longer list of links.

It adds the "icon links" and support button to our footer as well.

It removes duplication of copyright content so that it now only exists in the content footer.