### PR TITLE
Adjust dark theme blue color for accessibility

### DIFF
--- a/src/sphinx_2i2c_theme/assets/styles/abstract/_variables.scss
+++ b/src/sphinx_2i2c_theme/assets/styles/abstract/_variables.scss
@@ -11,6 +11,11 @@
   --logo-bold: 800;
 }
 
+/* Dark mode special-cases (usually for accessibility) */
+:root[data-theme=dark] {
+  --pst-color-primary: #5077FC;
+}
+
 // Copied from sphinx-book-theme
 // Breakpoints from Bootstrap: https://getbootstrap.com/docs/5.0/layout/breakpoints/
 $breakpoint-xxl: 1200px;


### PR DESCRIPTION
This slightly modifies our blue color per the recommendation from @trallard so that it meets basic visual accessibility standards. Here's the reference we used for this:

https://color.review/check/5077FC-14181F

See the following issue for a lot more information:

- closes https://github.com/2i2c-org/sphinx-2i2c-theme/issues/26

Many thanks for this guidance @trallard !

As a follow-up we should do something similar in the 2i2c.org site, but it's not as clear what change would be needed for it so I likely don't have time to do an in-depth look.
