### PR TITLE
FEAT: add last-updated to footer

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,3 +14,4 @@ python:
  # Build documentation in the docs/ directory with Sphinx
 sphinx:
    builder: dirhtml
+   configuration: docs/conf.py

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-content-footer.html
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-content-footer.html
@@ -1,2 +1,3 @@
 {%- if version %}<p id="footer-version">Version <span>{{ version }}</span>.</p>{% endif %}
 <p id="footer-attribution">By the <a id="footer-link" href='https://2i2c.org'>International Interactive Computing Collaboration</a> (2i2c)</p>
+{%- if last_updated %}<p id="footer-last-updated">Last Updated <span>{{ last_updated }}</span>.</p>{% endif %}


### PR DESCRIPTION
This PR adds a last-updated entry to the content footer. We can use this in conjunction with https://github.com/mgeier/sphinx-last-updated-by-git/ to keep track of when a page was last modified.
 
![image](https://github.com/user-attachments/assets/b58cd071-42a7-4c0e-ad3f-4263a4ef37f5)
