### PR TITLE
Add mailing list links and fix header and footer

### DIFF
--- a/src/sphinx_2i2c_theme/assets/styles/sections/_footer.scss
+++ b/src/sphinx_2i2c_theme/assets/styles/sections/_footer.scss
@@ -1,9 +1,18 @@
+// Remove the content footer because we don't use it
+footer.bd-footer-content {
+  display: none;
+}
+.bd-content {
+  padding-bottom: 1em; // A bit of extra space since the content footer is gone
+}
+
 // The icon links to the right
 .bd-footer .footer-items__end {
   justify-content: start;
 
   .navbar-icon-links {
     flex-direction: row-reverse;
+    justify-content: right;
   }
 }
 

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-content-footer.html
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-content-footer.html
@@ -1,3 +1,0 @@
-{%- if version %}<p id="footer-version">Version <span>{{ version }}</span>.</p>{% endif %}
-<p id="footer-attribution">By the <a id="footer-link" href='https://2i2c.org'>International Interactive Computing Collaboration</a> (2i2c)</p>
-{%- if last_updated %}<p id="footer-last-updated">Last Updated <span>{{ last_updated }}</span>.</p>{% endif %}

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-footer.html
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-footer.html
@@ -1,8 +1,8 @@
 {% set header_config = [
   ("https://docs.2i2c.org/en/latest/", "Service Docs"),
   ("https://infrastructure.2i2c.org/en/latest/", "Infrastructure Guide"),
-  ("https://team-compass.2i2c.org/", "2i2c Team Compass"),
-  ("https://2i2c.org/", "2i2c.org"),
+  ("https://2i2c.org/blog", "2i2c Blog"),
+  ("https://2i2c.org/mailing-list", "Mailing List"),
 ]
 %}
 <p class="footer-links-title">2i2c links</p>

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-header-links.html
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/components/2i2c-header-links.html
@@ -1,6 +1,8 @@
 {% set header_config = [
   ("https://docs.2i2c.org/en/latest/", "Service Docs"),
   ("https://infrastructure.2i2c.org/en/latest/", "Infrastructure Guide"),
+  ("https://2i2c.org/blog", "2i2c Blog"),
+  ("https://2i2c.org/mailing-list", "Mailing List"),
 ]
 %}
 <ul class="header-dropdown-links navbar-nav d-flex">

--- a/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/theme.conf
+++ b/src/sphinx_2i2c_theme/theme/sphinx-2i2c-theme/theme.conf
@@ -11,8 +11,9 @@ navbar_start = components/2i2c-logo.html
 navbar_center = components/2i2c-header-links.html
 navbar_end = icon-links.html
 navbar_persistent = components/2i2c-support-button.html
+navbar_align = left
 
 # Footer
 footer_start = components/2i2c-footer.html
 footer_end = icon-links.html, components/2i2c-support-button.html
-footer_content_items = 2i2c-content-footer.html
+footer_content_items = 


### PR DESCRIPTION
A few changes:

- Adds a few links to our blog and mailing list to the navbar and footer
- Snaps the header links to the left so it's cleaner
- Fixes the footer spacing
- Removes the content footer since we don't use it