### PR TITLE
Fix sidebar with hacky javascript

### DIFF
--- a/docs/_static/fix-sidebar-toggle.js
+++ b/docs/_static/fix-sidebar-toggle.js
@@ -1,0 +1,9 @@
+// Fix for sidebar toggle buttons.
+// The parent theme only attaches to the first .primary-toggle button,
+// but this theme has multiple buttons. This attaches to all of them.
+document.addEventListener("DOMContentLoaded", function() {
+    const checkbox = document.getElementById("pst-primary-sidebar-checkbox");
+    document.querySelectorAll(".primary-toggle").forEach(function(btn) {
+        btn.onclick = function() { checkbox.checked = !checkbox.checked; };
+    });
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ ogp_social_cards = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_js_files = ["fix-sidebar-toggle.js"]
 
 
 html_theme_options = {

--- a/src/sphinx_2i2c_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/sphinx_2i2c_theme/assets/styles/sections/_sidebar-primary.scss
@@ -29,9 +29,3 @@
     }
   }
 }
-
-// Both sidebars (if the secondary sidebar gets many more rules, create its own SCSS file)
-.bd-sidebar-primary, .bd-sidebar-secondary {
-  // Stick to the top
-  top: 0;
-}


### PR DESCRIPTION
this is a hack so the event listener is properly hooked up, not a long term fix, but I think this is not a long term theme. For some reason it isn't broken on the book theme, so that's why I'm doing a hacky fix here.